### PR TITLE
Adding PUBLIC director reset methods in base class

### DIFF
--- a/vrlib/src/main/java/com/asha/vrlib/MDVRLibrary.java
+++ b/vrlib/src/main/java/com/asha/vrlib/MDVRLibrary.java
@@ -658,4 +658,22 @@ public class MDVRLibrary {
         int BITMAP = 1;
         int DEFAULT = VIDEO;
     }
+
+    public void resetDirectors(float density, float damping){
+        List<MD360Director> directors = mProjectionModeManager.getDirectors();
+        for (MD360Director director : directors){
+            float x = director.getDeltaX();
+            float y = director.getDeltaY();
+            director.setDeltaX(x - x / density * damping);
+            director.setDeltaY(y - y / density * damping);
+        }
+    }
+
+    public void resetDirectors(){
+        List<MD360Director> directors = mProjectionModeManager.getDirectors();
+        for (MD360Director director : directors){
+            director.setDeltaX(0);
+            director.setDeltaY(0);
+        }
+    }
 }


### PR DESCRIPTION
Added two methods to reset directors on button click or hold  to where X and Y is 0, i.e. deltaX and deltaY are 0. Would you add this in next build or create a public access for getDirectors() from projectionModeManager
