### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ https://github.com/ashqal/MD360Player4Android/wiki/Advanced-Usage
 * or QQ Group.<br/>
 ![QQ Group](https://cloud.githubusercontent.com/assets/5126517/16213934/e398b010-3785-11e6-8877-5d88d9dc3f33.jpeg)
 
-##LICENSE
+## LICENSE
 ```
 Copyright 2016 Asha
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
