### PR TITLE
Fix #198

### DIFF
--- a/vrlib/src/main/java/com/asha/vrlib/objects/MDAbsObject3D.java
+++ b/vrlib/src/main/java/com/asha/vrlib/objects/MDAbsObject3D.java
@@ -47,8 +47,7 @@ public abstract class MDAbsObject3D {
         int textureCoordinateHandle = program.getTextureCoordinateHandle();
 
         // for cubemap variable is removed by compiler
-        if(textureCoordinateHandle == -1)
-            return;
+        if(textureCoordinateHandle == -1) return;
 
         FloatBuffer textureBuffer = getTexCoordinateBuffer(index);
         if (textureBuffer == null) return;

--- a/vrlib/src/main/java/com/asha/vrlib/objects/MDAbsObject3D.java
+++ b/vrlib/src/main/java/com/asha/vrlib/objects/MDAbsObject3D.java
@@ -44,16 +44,20 @@ public abstract class MDAbsObject3D {
     }
 
     public void uploadTexCoordinateBufferIfNeed(MD360Program program, int index){
+        int textureCoordinateHandle = program.getTextureCoordinateHandle();
+
+        // for cubemap variable is removed by compiler
+        if(textureCoordinateHandle == -1)
+            return;
+
         FloatBuffer textureBuffer = getTexCoordinateBuffer(index);
         if (textureBuffer == null) return;
 
         textureBuffer.position(0);
 
         // set data to OpenGL
-        int textureCoordinateHandle = program.getTextureCoordinateHandle();
         GLES20.glVertexAttribPointer(textureCoordinateHandle, sTextureCoordinateDataSize, GLES20.GL_FLOAT, false, 0, textureBuffer);
         GLES20.glEnableVertexAttribArray(textureCoordinateHandle);
-
     }
 
     abstract protected void executeLoad(Context context);


### PR DESCRIPTION
Fixed `glError 0x501` which is caused by variable `a_TexCoordinate` in the vertex shader not existing during runtime. Since it is not needed in the cubemap fragment shader, the compiler dismisses the variable.